### PR TITLE
prometheus metrics availability fixed

### DIFF
--- a/pkg/reconciler/ceph/controller.go
+++ b/pkg/reconciler/ceph/controller.go
@@ -54,7 +54,7 @@ func NewController(
 		dr:  &reconciler.DeploymentReconciler{KubeClientSet: kubeclient.Get(ctx)},
 		sbr: &reconciler.SinkBindingReconciler{EventingClientSet: eventingclient.Get(ctx)},
 		// Config accessor takes care of tracing/config/logging config propagation to the receive adapter
-		configAccessor: reconcilersource.WatchConfigurations(ctx, "ceph-source", cmw),
+		configAccessor: reconcilersource.WatchConfigurations(ctx, "cephsource", cmw),
 	}
 	if err := envconfig.Process("", r); err != nil {
 		logging.FromContext(ctx).Panicf("required environment variable is not defined: %v", err)


### PR DESCRIPTION
Fixes #156 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Component name changed to `cephsource` in controller.go, since `ceph-source` is invalid in a prometheus metric name because of the hyphen. 
- Added metric tag in the context
- Make endpoints RFC 7231 (HTTP) compliant by reporting Allow header on 405 - motivated from this PR: https://github.com/knative/eventing/pull/5542

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
