### PR TITLE
logging levels changed and basic refactoring

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -113,15 +113,11 @@ func (ca *cephReceiveAdapter) postMessage(notification ceph.BucketNotification) 
 	}
 	ctx = adapter.ContextWithMetricTag(ctx, metricTag)
 
-	if err := ca.sendCloudEvent(ctx, event); err != nil {
-		return err
-	}
-	return nil
+	return ca.sendCloudEvent(ctx, event)
 }
 
 // sendCloudEvent sends a cloudevent for a ceph notification.
 func (ca *cephReceiveAdapter) sendCloudEvent(ctx context.Context, event cloudevents.Event) error {
-	defer ca.logger.Debug("Finished sending cloudevent id: ", event.ID())
 	source := event.Context.GetSource()
 	subject := event.Context.GetSubject()
 	ca.logger.Debugf("sending cloudevent id: %s, source: %s, subject: %s", event.ID(), source, subject)


### PR DESCRIPTION
Fixes #
Changes logging levels to debug, following the same convention as pingsource and apiserversource. 
For reference: https://github.com/knative/eventing/blob/main/pkg/adapter/apiserver/delegate.go#L70
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change all the info levels to debug, to avoid lots of logs for every post to a sink. 

To see the same logs now in debug level, the  logging level in `config-logging` cm would have to be changed, and then the cephsource will have to be recreated - this logging change should happen at runtime but seems like its blocked by https://github.com/knative/eventing/issues/5693

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
