### PR TITLE
Metric label fix

### DIFF
--- a/pkg/reconciler/ceph/resources/labels.go
+++ b/pkg/reconciler/ceph/resources/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/ceph/resources/labels.go
+++ b/pkg/reconciler/ceph/resources/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package resources
 const (
 	// controllerAgentName is the string used by this controller to identify
 	// itself when creating events.
-	controllerAgentName = "ceph-controller"
+	controllerAgentName = "ceph-source-controller"
 )
 
 func Labels(name string) map[string]string {
 	return map[string]string{
-		"knative-eventing-source":      controllerAgentName,
-		"knative-eventing-source-name": name,
+		"eventing.knative.dev/source":     controllerAgentName,
+		"eventing.knative.dev/sourceName": name,
 	}
 }

--- a/pkg/reconciler/ceph/resources/receive_adapter.go
+++ b/pkg/reconciler/ceph/resources/receive_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/ceph/resources/receive_adapter.go
+++ b/pkg/reconciler/ceph/resources/receive_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #
Related to https://github.com/knative/eventing/issues/5942 - here the `name` label used to show the receive adapter pod name instead of the CR name. 
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Changed the `makeEnv()` function to use the CR's name instead of the pod name, similar to how its done in `APIServerSource`
- Added `metrics` port in the receive adapter container and renamed the labels, same as `PingSource` and `APIServerSource`, so that a `PodMonitor` like here (for apiserversource) can be used for cephsource as well: https://github.com/knative-sandbox/monitoring/blob/main/servicemonitor.yaml#L157 

